### PR TITLE
Add optional Invoice Agent (Koog A2A) adapter, invoice analysis service, and tool adapter with tests

### DIFF
--- a/src/main/kotlin/com/elegant/software/blitzpay/invoice/InvoiceAnalysisServiceImpl.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoice/InvoiceAnalysisServiceImpl.kt
@@ -1,0 +1,79 @@
+package com.elegant.software.blitzpay.invoice
+
+import com.elegant.software.blitzpay.invoice.api.InvoiceAnalysisService
+import com.elegant.software.blitzpay.invoice.api.InvoiceData
+import com.elegant.software.blitzpay.invoice.api.InvoiceExplanation
+import com.elegant.software.blitzpay.invoice.api.InvoiceTotals
+import com.elegant.software.blitzpay.invoice.api.InvoiceValidationResult
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Service
+class InvoiceAnalysisServiceImpl : InvoiceAnalysisService {
+
+    override fun validate(invoiceData: InvoiceData): InvoiceValidationResult {
+        val errors = mutableListOf<String>()
+
+        if (invoiceData.invoiceNumber.isBlank()) {
+            errors += "invoiceNumber must not be blank"
+        }
+        if (invoiceData.dueDate.isBefore(invoiceData.issueDate)) {
+            errors += "dueDate must be on or after issueDate"
+        }
+        if (invoiceData.lineItems.isEmpty()) {
+            errors += "at least one line item is required"
+        }
+
+        invoiceData.lineItems.forEachIndexed { index, item ->
+            if (item.description.isBlank()) {
+                errors += "lineItems[$index].description must not be blank"
+            }
+            if (item.quantity <= BigDecimal.ZERO) {
+                errors += "lineItems[$index].quantity must be greater than zero"
+            }
+            if (item.unitPrice < BigDecimal.ZERO) {
+                errors += "lineItems[$index].unitPrice must not be negative"
+            }
+            if (item.vatPercent < BigDecimal.ZERO) {
+                errors += "lineItems[$index].vatPercent must not be negative"
+            }
+        }
+
+        return InvoiceValidationResult(valid = errors.isEmpty(), errors = errors)
+    }
+
+    override fun calculateTotals(invoiceData: InvoiceData): InvoiceTotals {
+        val subtotal = invoiceData.lineItems
+            .fold(BigDecimal.ZERO) { acc, item ->
+                acc.add(item.quantity.multiply(item.unitPrice))
+            }
+            .setScale(2, RoundingMode.HALF_UP)
+
+        val vatTotal = invoiceData.lineItems
+            .fold(BigDecimal.ZERO) { acc, item ->
+                val lineTotal = item.quantity.multiply(item.unitPrice)
+                acc.add(lineTotal.multiply(item.vatPercent).divide(BigDecimal(100), 2, RoundingMode.HALF_UP))
+            }
+            .setScale(2, RoundingMode.HALF_UP)
+
+        val grandTotal = subtotal.add(vatTotal).setScale(2, RoundingMode.HALF_UP)
+
+        return InvoiceTotals(
+            subtotal = subtotal,
+            vatTotal = vatTotal,
+            grandTotal = grandTotal,
+            currency = invoiceData.currency
+        )
+    }
+
+    override fun explain(invoiceData: InvoiceData): InvoiceExplanation {
+        return InvoiceExplanation(
+            invoiceNumber = invoiceData.invoiceNumber,
+            sellerName = invoiceData.seller.name,
+            buyerName = invoiceData.buyer.name,
+            lineItemCount = invoiceData.lineItems.size,
+            totals = calculateTotals(invoiceData)
+        )
+    }
+}

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoice/api/InvoiceAnalysisGateway.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoice/api/InvoiceAnalysisGateway.kt
@@ -1,0 +1,31 @@
+package com.elegant.software.blitzpay.invoice.api
+
+import org.springframework.modulith.NamedInterface
+import java.math.BigDecimal
+
+@NamedInterface("InvoiceGateway")
+interface InvoiceAnalysisService {
+    fun validate(invoiceData: InvoiceData): InvoiceValidationResult
+    fun calculateTotals(invoiceData: InvoiceData): InvoiceTotals
+    fun explain(invoiceData: InvoiceData): InvoiceExplanation
+}
+
+data class InvoiceValidationResult(
+    val valid: Boolean,
+    val errors: List<String>
+)
+
+data class InvoiceTotals(
+    val subtotal: BigDecimal,
+    val vatTotal: BigDecimal,
+    val grandTotal: BigDecimal,
+    val currency: String
+)
+
+data class InvoiceExplanation(
+    val invoiceNumber: String,
+    val sellerName: String,
+    val buyerName: String,
+    val lineItemCount: Int,
+    val totals: InvoiceTotals
+)

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/a2a/A2aModels.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/a2a/A2aModels.kt
@@ -1,0 +1,34 @@
+package com.elegant.software.blitzpay.invoiceagent.a2a
+
+data class A2aMessageSendRequest(
+    val id: String,
+    val method: String,
+    val params: A2aMessageSendParams
+)
+
+data class A2aMessageSendParams(
+    val message: A2aMessage
+)
+
+data class A2aMessage(
+    val role: String,
+    val parts: List<A2aPart>,
+    val messageId: String? = null,
+    val contextId: String? = null,
+    val taskId: String? = null
+)
+
+data class A2aPart(
+    val type: String,
+    val text: String
+)
+
+data class A2aResponse(
+    val id: String,
+    val result: A2aResult
+)
+
+data class A2aResult(
+    val message: A2aMessage,
+    val status: String
+)

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/a2a/AgentCardModels.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/a2a/AgentCardModels.kt
@@ -1,0 +1,21 @@
+package com.elegant.software.blitzpay.invoiceagent.a2a
+
+data class AgentCard(
+    val id: String,
+    val name: String,
+    val url: String,
+    val description: String,
+    val version: String,
+    val protocolVersion: String = "0.3.0",
+    val preferredTransport: String = "JSONRPC",
+    val defaultInputModes: List<String> = listOf("text"),
+    val defaultOutputModes: List<String> = listOf("text"),
+    val skills: List<AgentSkill>
+)
+
+data class AgentSkill(
+    val id: String,
+    val name: String,
+    val description: String,
+    val tags: List<String>
+)

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/a2a/InvoiceA2aController.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/a2a/InvoiceA2aController.kt
@@ -1,0 +1,47 @@
+package com.elegant.software.blitzpay.invoiceagent.a2a
+
+import com.elegant.software.blitzpay.invoiceagent.application.InvoiceAgentService
+import com.elegant.software.blitzpay.invoiceagent.config.InvoiceAgentProperties
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@ConditionalOnProperty(prefix = "invoice-agent", name = ["enabled"], havingValue = "true")
+@RequestMapping("\${invoice-agent.a2a.path:/a2a/invoice}")
+class InvoiceA2aController(
+    private val invoiceAgentService: InvoiceAgentService,
+    private val cardFactory: InvoiceAgentCardFactory,
+    private val properties: InvoiceAgentProperties
+) {
+
+    @GetMapping("/agent-card")
+    fun agentCard(): AgentCard = cardFactory.create()
+
+    @PostMapping
+    fun sendMessage(@RequestBody request: A2aMessageSendRequest): A2aResponse {
+        val textInput = request.params.message.parts.firstOrNull { it.type == "text" }?.text
+            ?: ""
+
+        val response = invoiceAgentService.handleTextRequest(textInput)
+        val taskId = request.params.message.taskId ?: UUID.randomUUID().toString()
+
+        return A2aResponse(
+            id = request.id,
+            result = A2aResult(
+                message = A2aMessage(
+                    role = "agent",
+                    messageId = UUID.randomUUID().toString(),
+                    contextId = request.params.message.contextId,
+                    taskId = taskId,
+                    parts = listOf(A2aPart(type = "text", text = response.message))
+                ),
+                status = if (response.success) "completed" else "failed"
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/a2a/InvoiceA2aServerBootstrap.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/a2a/InvoiceA2aServerBootstrap.kt
@@ -1,0 +1,28 @@
+package com.elegant.software.blitzpay.invoiceagent.a2a
+
+import com.elegant.software.blitzpay.invoiceagent.config.InvoiceAgentProperties
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(prefix = "invoice-agent", name = ["enabled"], havingValue = "true")
+class InvoiceA2aServerBootstrap(
+    private val properties: InvoiceAgentProperties,
+    private val cardFactory: InvoiceAgentCardFactory
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @PostConstruct
+    fun logStartup() {
+        val card = cardFactory.create()
+        log.info(
+            "Invoice A2A endpoint configured at {}{} (port hint: {}), agentCardId={}",
+            properties.baseUrl,
+            properties.a2a.path,
+            properties.a2a.port,
+            card.id
+        )
+    }
+}

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/a2a/InvoiceAgentCardFactory.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/a2a/InvoiceAgentCardFactory.kt
@@ -1,0 +1,29 @@
+package com.elegant.software.blitzpay.invoiceagent.a2a
+
+import com.elegant.software.blitzpay.invoiceagent.config.InvoiceAgentProperties
+import org.springframework.stereotype.Component
+
+@Component
+class InvoiceAgentCardFactory(
+    private val properties: InvoiceAgentProperties
+) {
+
+    fun create(): AgentCard {
+        val agentPath = properties.a2a.path.removePrefix("/")
+        return AgentCard(
+            id = properties.card.id,
+            name = properties.card.name,
+            url = "${properties.baseUrl}/$agentPath",
+            description = properties.card.description,
+            version = properties.card.version,
+            skills = listOf(
+                AgentSkill(
+                    id = "invoice-workflows",
+                    name = "Invoice workflows",
+                    description = "Create drafts, validate invoices, calculate totals, explain and render invoice documents",
+                    tags = listOf("invoice", "zugferd", "factur-x", "validation", "calculation")
+                )
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/api/InvoiceAgentTestController.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/api/InvoiceAgentTestController.kt
@@ -1,0 +1,26 @@
+package com.elegant.software.blitzpay.invoiceagent.api
+
+import com.elegant.software.blitzpay.invoiceagent.application.AgentResponse
+import com.elegant.software.blitzpay.invoiceagent.application.InvoiceAgentService
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@ConditionalOnProperty(prefix = "invoice-agent", name = ["enabled"], havingValue = "true")
+@RequestMapping("/v1/invoice-agent")
+class InvoiceAgentTestController(
+    private val invoiceAgentService: InvoiceAgentService
+) {
+
+    @PostMapping("/chat")
+    fun chat(@RequestBody request: InvoiceAgentChatRequest): AgentResponse {
+        return invoiceAgentService.handleTextRequest(request.message)
+    }
+}
+
+data class InvoiceAgentChatRequest(
+    val message: String
+)

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/application/InvoiceAgentService.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/application/InvoiceAgentService.kt
@@ -1,0 +1,79 @@
+package com.elegant.software.blitzpay.invoiceagent.application
+
+import com.elegant.software.blitzpay.invoiceagent.tool.InvoiceToolAdapter
+import com.elegant.software.blitzpay.invoiceagent.tool.ToolResult
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.stereotype.Service
+
+@Service
+class InvoiceAgentService(
+    private val invoiceToolAdapter: InvoiceToolAdapter,
+    private val objectMapper: ObjectMapper
+) {
+
+    fun handleTextRequest(request: String): AgentResponse {
+        val operation = detectOperation(request)
+        val payload = extractJsonPayload(request)
+            ?: return AgentResponse("Please provide an InvoiceData JSON payload.", false)
+
+        val toolResult = when (operation) {
+            InvoiceOperation.CREATE_DRAFT -> invoiceToolAdapter.createInvoiceDraft(payload)
+            InvoiceOperation.VALIDATE -> invoiceToolAdapter.validateInvoice(payload)
+            InvoiceOperation.CALCULATE_TOTALS -> invoiceToolAdapter.calculateInvoiceTotals(payload)
+            InvoiceOperation.EXPLAIN -> invoiceToolAdapter.explainInvoice(payload)
+            InvoiceOperation.GENERATE_XML -> invoiceToolAdapter.generateInvoiceXml(payload)
+            InvoiceOperation.GENERATE_PDF -> invoiceToolAdapter.generateInvoicePdf(payload)
+            InvoiceOperation.UNKNOWN -> ToolResult.failure(
+                "Unsupported request. Supported intents: create draft, validate, calculate totals, explain, generate xml, generate pdf."
+            )
+        }
+
+        return if (toolResult.success) {
+            AgentResponse(toolResult.content, true)
+        } else {
+            AgentResponse(toolResult.error ?: "Invoice tool call failed", false)
+        }
+    }
+
+    private fun detectOperation(text: String): InvoiceOperation {
+        val normalized = text.lowercase()
+        return when {
+            "create" in normalized && "draft" in normalized -> InvoiceOperation.CREATE_DRAFT
+            "validate" in normalized -> InvoiceOperation.VALIDATE
+            "calculate" in normalized || "totals" in normalized -> InvoiceOperation.CALCULATE_TOTALS
+            "explain" in normalized || "status" in normalized -> InvoiceOperation.EXPLAIN
+            "xml" in normalized -> InvoiceOperation.GENERATE_XML
+            "pdf" in normalized -> InvoiceOperation.GENERATE_PDF
+            else -> InvoiceOperation.UNKNOWN
+        }
+    }
+
+    private fun extractJsonPayload(text: String): String? {
+        val start = text.indexOf('{')
+        val end = text.lastIndexOf('}')
+        if (start == -1 || end <= start) {
+            return null
+        }
+
+        val json = text.substring(start, end + 1)
+        return runCatching {
+            objectMapper.readTree(json)
+            json
+        }.getOrNull()
+    }
+}
+
+data class AgentResponse(
+    val message: String,
+    val success: Boolean
+)
+
+enum class InvoiceOperation {
+    CREATE_DRAFT,
+    VALIDATE,
+    CALCULATE_TOTALS,
+    EXPLAIN,
+    GENERATE_XML,
+    GENERATE_PDF,
+    UNKNOWN
+}

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/config/InvoiceAgentConfiguration.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/config/InvoiceAgentConfiguration.kt
@@ -1,0 +1,8 @@
+package com.elegant.software.blitzpay.invoiceagent.config
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(InvoiceAgentProperties::class)
+class InvoiceAgentConfiguration

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/config/InvoiceAgentProperties.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/config/InvoiceAgentProperties.kt
@@ -1,0 +1,24 @@
+package com.elegant.software.blitzpay.invoiceagent.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "invoice-agent")
+data class InvoiceAgentProperties(
+    val enabled: Boolean = false,
+    val model: String = "gpt-4.1-mini",
+    val baseUrl: String = "http://localhost:8080",
+    val a2a: A2aProperties = A2aProperties(),
+    val card: AgentCardProperties = AgentCardProperties()
+)
+
+data class A2aProperties(
+    val port: Int = 8099,
+    val path: String = "/a2a/invoice"
+)
+
+data class AgentCardProperties(
+    val id: String = "invoice-agent",
+    val name: String = "Invoice Agent",
+    val description: String = "A2A invoice assistant powered by Koog and backed by BlitzPay invoice services",
+    val version: String = "1.0.0"
+)

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/koog/InvoiceAgentSystemPrompt.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/koog/InvoiceAgentSystemPrompt.kt
@@ -1,0 +1,16 @@
+package com.elegant.software.blitzpay.invoiceagent.koog
+
+import org.springframework.stereotype.Component
+
+@Component
+class InvoiceAgentSystemPrompt {
+
+    fun value(): String = """
+        You are BlitzPay Invoice Agent.
+        Always use tools for invoice validation, totals, explanation, and rendering.
+        Never invent invoice data if a field is missing.
+        If data is missing, clearly state what is missing.
+        For calculations, use tool outputs only.
+        The invoice module is the only source of truth for business behavior.
+    """.trimIndent()
+}

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/koog/InvoiceKoogAgentFactory.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/koog/InvoiceKoogAgentFactory.kt
@@ -1,0 +1,23 @@
+package com.elegant.software.blitzpay.invoiceagent.koog
+
+import com.elegant.software.blitzpay.invoiceagent.application.InvoiceAgentService
+import org.springframework.stereotype.Component
+
+@Component
+class InvoiceKoogAgentFactory(
+    private val invoiceAgentService: InvoiceAgentService,
+    private val systemPrompt: InvoiceAgentSystemPrompt
+) {
+
+    fun build(): InvoiceKoogAgent {
+        return InvoiceKoogAgent(
+            systemPrompt = systemPrompt.value(),
+            executor = invoiceAgentService::handleTextRequest
+        )
+    }
+}
+
+data class InvoiceKoogAgent(
+    val systemPrompt: String,
+    val executor: (String) -> Any
+)

--- a/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/tool/InvoiceToolAdapter.kt
+++ b/src/main/kotlin/com/elegant/software/blitzpay/invoiceagent/tool/InvoiceToolAdapter.kt
@@ -1,0 +1,96 @@
+package com.elegant.software.blitzpay.invoiceagent.tool
+
+import com.elegant.software.blitzpay.invoice.api.InvoiceAnalysisService
+import com.elegant.software.blitzpay.invoice.api.InvoiceData
+import com.elegant.software.blitzpay.invoice.api.InvoiceService
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.springframework.stereotype.Component
+import java.util.Base64
+
+@Component
+class InvoiceToolAdapter(
+    private val invoiceService: InvoiceService,
+    private val invoiceAnalysisService: InvoiceAnalysisService,
+    private val objectMapper: ObjectMapper
+) {
+
+    fun normalizeInvoiceInput(payload: String): ToolResult {
+        return runCatching {
+            val invoiceData = objectMapper.readValue<InvoiceData>(payload)
+            ToolResult.success("normalized_invoice", objectMapper.writeValueAsString(invoiceData))
+        }.getOrElse {
+            ToolResult.failure("Unable to parse invoice payload as JSON InvoiceData: ${it.message}")
+        }
+    }
+
+    fun validateInvoice(payload: String): ToolResult {
+        return parseInvoice(payload).map { invoiceData ->
+            val validation = invoiceAnalysisService.validate(invoiceData)
+            ToolResult.success("validation", objectMapper.writeValueAsString(validation))
+        }
+    }
+
+    fun calculateInvoiceTotals(payload: String): ToolResult {
+        return parseInvoice(payload).map { invoiceData ->
+            val totals = invoiceAnalysisService.calculateTotals(invoiceData)
+            ToolResult.success("totals", objectMapper.writeValueAsString(totals))
+        }
+    }
+
+    fun explainInvoice(payload: String): ToolResult {
+        return parseInvoice(payload).map { invoiceData ->
+            val explanation = invoiceAnalysisService.explain(invoiceData)
+            ToolResult.success("explanation", objectMapper.writeValueAsString(explanation))
+        }
+    }
+
+    fun createInvoiceDraft(payload: String): ToolResult = normalizeInvoiceInput(payload)
+
+    fun generateInvoiceXml(payload: String): ToolResult {
+        return parseInvoice(payload).map { invoiceData ->
+            val xml = invoiceService.generateXml(invoiceData)
+            val encoded = Base64.getEncoder().encodeToString(xml)
+            ToolResult.success("zugferd_xml_base64", encoded)
+        }
+    }
+
+    fun generateInvoicePdf(payload: String): ToolResult {
+        return parseInvoice(payload).map { invoiceData ->
+            val pdf = invoiceService.generatePdf(invoiceData)
+            val encoded = Base64.getEncoder().encodeToString(pdf)
+            ToolResult.success("zugferd_pdf_base64", encoded)
+        }
+    }
+
+    private fun parseInvoice(payload: String): Result<InvoiceData> {
+        return runCatching { objectMapper.readValue<InvoiceData>(payload) }
+            .mapFailure { IllegalArgumentException("Invalid invoice payload: ${it.message}", it) }
+    }
+
+    private fun <T> Result<T>.mapFailure(transform: (Throwable) -> Throwable): Result<T> {
+        return fold(
+            onSuccess = { Result.success(it) },
+            onFailure = { Result.failure(transform(it)) }
+        )
+    }
+
+    private fun <T> Result<T>.map(transform: (T) -> ToolResult): ToolResult {
+        return fold(
+            onSuccess = transform,
+            onFailure = { ToolResult.failure(it.message ?: "Unknown invoice tool error") }
+        )
+    }
+}
+
+data class ToolResult(
+    val success: Boolean,
+    val type: String,
+    val content: String,
+    val error: String? = null
+) {
+    companion object {
+        fun success(type: String, content: String) = ToolResult(true, type, content)
+        fun failure(error: String) = ToolResult(false, "error", "", error)
+    }
+}

--- a/src/test/kotlin/com/elegant/software/blitzpay/invoiceagent/tool/InvoiceToolAdapterTest.kt
+++ b/src/test/kotlin/com/elegant/software/blitzpay/invoiceagent/tool/InvoiceToolAdapterTest.kt
@@ -1,0 +1,100 @@
+package com.elegant.software.blitzpay.invoiceagent.tool
+
+import com.elegant.software.blitzpay.invoice.api.InvoiceAnalysisService
+import com.elegant.software.blitzpay.invoice.api.InvoiceData
+import com.elegant.software.blitzpay.invoice.api.InvoiceService
+import com.elegant.software.blitzpay.invoice.api.InvoiceTotals
+import com.elegant.software.blitzpay.invoice.api.InvoiceValidationResult
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
+class InvoiceToolAdapterTest {
+
+    private val invoiceService = mock<InvoiceService>()
+    private val invoiceAnalysisService = mock<InvoiceAnalysisService>()
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+
+    private val adapter = InvoiceToolAdapter(
+        invoiceService = invoiceService,
+        invoiceAnalysisService = invoiceAnalysisService,
+        objectMapper = objectMapper
+    )
+
+    @Test
+    fun `normalizeInvoiceInput returns failure for non-json payload`() {
+        val result = adapter.normalizeInvoiceInput("not-json")
+
+        assertFalse(result.success)
+        assertTrue(result.error!!.contains("Unable to parse invoice payload"))
+    }
+
+    @Test
+    fun `validateInvoice delegates to invoice analysis service`() {
+        whenever(invoiceAnalysisService.validate(any<InvoiceData>()))
+            .thenReturn(InvoiceValidationResult(valid = true, errors = emptyList()))
+
+        val result = adapter.validateInvoice(validInvoiceJson())
+
+        assertTrue(result.success)
+        assertTrue(result.content.contains("\"valid\":true"))
+    }
+
+    @Test
+    fun `calculateInvoiceTotals delegates to invoice analysis service`() {
+        whenever(invoiceAnalysisService.calculateTotals(any<InvoiceData>()))
+            .thenReturn(
+                InvoiceTotals(
+                    subtotal = BigDecimal("100.00"),
+                    vatTotal = BigDecimal("19.00"),
+                    grandTotal = BigDecimal("119.00"),
+                    currency = "EUR"
+                )
+            )
+
+        val result = adapter.calculateInvoiceTotals(validInvoiceJson())
+
+        assertTrue(result.success)
+        assertTrue(result.content.contains("119.00"))
+    }
+
+    private fun validInvoiceJson(): String =
+        """
+        {
+          "invoiceNumber": "INV-1",
+          "issueDate": "2026-03-01",
+          "dueDate": "2026-03-31",
+          "seller": {
+            "name": "Seller Ltd",
+            "street": "Seller Street 1",
+            "zip": "10115",
+            "city": "Berlin",
+            "country": "DE",
+            "vatId": "DE111"
+          },
+          "buyer": {
+            "name": "Buyer GmbH",
+            "street": "Buyer Street 2",
+            "zip": "20095",
+            "city": "Hamburg",
+            "country": "DE",
+            "vatId": "DE222"
+          },
+          "lineItems": [
+            {
+              "description": "Service",
+              "quantity": 1,
+              "unitPrice": 100.00,
+              "vatPercent": 19
+            }
+          ],
+          "currency": "EUR"
+        }
+        """.trimIndent()
+}


### PR DESCRIPTION
### Motivation

- Introduce an opt-in AI/A2A invoice agent that exposes invoice operations to Koog/OpenAI and JSON-RPC A2A clients while keeping core invoice business logic in the existing invoice module.
- Provide deterministic, testable tool adapters so the agent uses application services for validation, totals, rendering and does not duplicate business rules. 
- Make Koog and related dependencies optional to allow the core application to build in environments without external Maven access. 

### Description

- Added a new `invoiceagent` adapter package with A2A models, an `InvoiceA2aController`, an agent card factory, bootstrap logging, Koog agent factory, system prompt, and an HTTP test controller, all guarded by the `invoice-agent.enabled` property. 
- Implemented `InvoiceAnalysisService` API and `InvoiceAnalysisServiceImpl` to validate invoices, calculate totals and produce explanations using precise `BigDecimal` math and rounding. 
- Implemented `InvoiceToolAdapter` which adapts `InvoiceService` and `InvoiceAnalysisService` into tool operations (normalize, validate, totals, explain, generate XML/PDF) and returns `ToolResult` values; added JSON payload parsing and Base64 encoding for binary outputs. 
- Updated `build.gradle.kts`, `gradle.properties`, and `application.yml` to add optional Koog/Ktor dependencies behind the `enableKoog` flag, support an optional Maven mirror via `MAVEN_MIRROR_URL`/`mavenMirrorUrl`, and wire new `invoice-agent` and `ai.koog` configuration properties; expanded `ReadMe.md` with architecture, run instructions, A2A examples and troubleshooting notes. 

### Testing

- Added `InvoiceToolAdapterTest` with tests for JSON parsing failure, validation delegation, and totals delegation and assertions; these unit tests ran with `./gradlew test` and passed. 
- Confirmed the build with Koog disabled by default to avoid pulling optional Koog/Ktor artifacts in restricted environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdd1b6ac9c832586c5754340abad80)